### PR TITLE
refactor: 💡 Food가 FoodLevel을 FK로 참조하도록 association을 추가합니다

### DIFF
--- a/src/food/entities/food.entity.ts
+++ b/src/food/entities/food.entity.ts
@@ -12,6 +12,7 @@ import {
   OneToMany,
 } from 'typeorm';
 import { Category } from './category.entity';
+import { FoodLevel } from './food_level.entity';
 import { Restaurant } from './restaurant.entity';
 
 @Entity()
@@ -41,6 +42,9 @@ export class Food {
   @ManyToMany(() => Category, { nullable: false })
   @JoinTable({ name: 'food_category' })
   categories: Category[];
+
+  @ManyToOne((type) => FoodLevel, (foodLevel) => foodLevel.foods)
+  foodLevel: FoodLevel;
 
   // 한 음식점에 여러 음식이 속할 수 있다고 가정
   // restaurant

--- a/src/food/entities/food_level.entity.ts
+++ b/src/food/entities/food_level.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Food } from './food.entity';
 
 @Entity()
 export class FoodLevel {
@@ -13,4 +14,8 @@ export class FoodLevel {
 
   @Column({ nullable: true })
   description: string;
+
+  // food
+  @OneToMany((type) => Food, (food) => food.foodLevel)
+  foods: Food[];
 }


### PR DESCRIPTION
# 주제

- Food 테이블에 현재 FoodLevel이 빠져있습니다. 연관관계를 생성합니다.

# 작업 완료 내용 (자세히 작성)

- Food에 `ManyToOne`으로 FoodLevel과 관계를 추가합니다.
- FoodLevel에 `OneToMany`로 Food와 관계를 추가합니다.

# 관련 이슈 번호

- #27 

# 미작업 내용

-

# 주의사항

- [ ]
