### PR TITLE
Feat #41 레벨 테스트용 음식 리스트 API 수정 및 Table 칼럼 추가

### DIFF
--- a/src/food/dto/create-food.dto.ts
+++ b/src/food/dto/create-food.dto.ts
@@ -8,6 +8,13 @@ export class CreateFoodDto {
   name: string;
 
   @IsString()
+  @ApiProperty({
+    description: '음식 맛 ex) 순한맛, 매운맛, 1단계, 2단계',
+    type: String,
+  })
+  subName: string;
+
+  @IsString()
   @ApiProperty({ description: '음식 레벨', type: String })
   level: string;
 

--- a/src/food/entities/food.entity.ts
+++ b/src/food/entities/food.entity.ts
@@ -26,6 +26,13 @@ export class Food {
   @ApiProperty({ description: '음식 이름', type: String })
   name: string;
 
+  @Column()
+  @ApiProperty({
+    description: '음식 맛 ex) 순한맛, 매운맛, 1단계, 2단계',
+    type: String,
+  })
+  subName: string;
+
   @CreateDateColumn({ type: 'datetime' })
   @ApiProperty({ description: '음식 데이터가 만들어진 일자', type: Date })
   createdAt: Date;

--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -34,7 +34,7 @@ export class FoodController {
     description: '테스트에 필요한 음식 리스트를 가져온다.',
   })
   @ApiCreatedResponse({ description: '음식 list', type: Food })
-  async testFoodList(): Promise<Food[]> {
+  async findTestFoodList(): Promise<Food[]> {
     return this.foodService.findTestFoods();
   }
 

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -29,17 +29,15 @@ export class FoodService {
   }
 
   async findTestFoods(): Promise<Food[]> {
-    const food = await this.foodRepository
+    return await this.foodRepository
       .createQueryBuilder('food')
-      .select()
+      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
       .where('food.isTest = true')
       .getMany();
-
-    return food;
   }
 
   async createFoodInfo(foodDetail: CreateFoodDto): Promise<CreateFoodDto> {
-    const { name, level, category } = foodDetail;
+    const { name, subName, level, category } = foodDetail;
 
     // foodLevelId을 사용하여 foodLevel 정보를 가져옴
     const foodLevel = await this.foodLevelRepository
@@ -54,7 +52,7 @@ export class FoodService {
       .leftJoin('food.foodLevel', 'foodLevel')
       .insert()
       .into(Food)
-      .values({ name, foodLevel })
+      .values({ name, subName, foodLevel })
       .execute()
       .then(({ identifiers }) => {
         if (identifiers.length !== 1) {
@@ -80,6 +78,7 @@ export class FoodService {
 
     return {
       name,
+      subName,
       level,
       category,
     };


### PR DESCRIPTION
# 주제

- 리뷰 테스트시 필요한 음식 12개에 대한 DB Table(Food) 칼럼 추가
- 리뷰 테스트시 필요한 음식 12개를 반환 하는 API 수정

# 작업 완료 내용 (자세히 작성)

- Food Table 칼럼 추가
 ``` Typescript
 // Food Table
@Column({ type: 'boolean', default: false })
  @ApiProperty({
    description: '사용자 레벨 테스트 확인용',
    type: Boolean,
    default: false,
  })
  isTest: boolean;
 ```
- `/food/tests` API 수정
 - 기존 `query`값(size) 제거 : `/food/tests?size=12` -> `/food/test`
 - Query Builder을 사용하여 isTest 값이 True인 값만 가져옴
 ```json
{
    "data": [
        {
            "id": "8",
            "name": "왕뚜껑",
            "subName": "일반",
            "imageUrl": null
        }
    ],
    "statusCode": 200,
    "message": "Success"
}
 ```

# 관련 이슈 번호

- #41 

# 미작업 내용

-

# 주의사항

- [ ]
