### PR TITLE
fix: 🐛 localhost:3000을 CORS 허용 origin으로 추가합니다

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     cors: {
       origin: [
+        'http://localhost:3000',
+        'http://127.0.0.1:3000',
         'https://ohmebddeng.kr',
         'https://www.ohmebddeng.kr',
         'https://ohmebddeng-frontend.vercel.app',


### PR DESCRIPTION
# 주제

-

# 작업 완료 내용 (자세히 작성)

- `http://localhost:3000`, `http://127.0.0.1:3000`을 CORS 허용 origin으로 추가합니다.

# 관련 이슈 번호

- #43 

# 미작업 내용

-

# 주의사항

- [ ]
