### PR TITLE
feat: 🎸 음식 리뷰 화면 음식 리스트 반환 API 구현

### DIFF
--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -40,10 +40,9 @@ export class FoodController {
     summary: '리뷰할 음식 리스트를 가져오는 API',
     description: '리뷰 할 음식 List을 가져온다.',
   })
-  @ApiQuery({ name: 'size' })
   @ApiCreatedResponse({ description: '음식 list', type: Food })
-  async reviewFoodList(@Query('size') size): Promise<Food[]> {
-    return this.foodService.findReviewFoods(size);
+  async reviewFoodList(): Promise<Food[]> {
+    return this.foodService.findReviewFoods();
   }
 
   @Get('/tests')

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -28,9 +28,14 @@ export class FoodService {
     this.categoryRepository = categoryRepository;
   }
 
-  async findReviewFoods(size): Promise<Food[]> {
-    const foodList = await this.foodRepository.find(size);
-    return foodList;
+  async findReviewFoods(): Promise<Food[]> {
+    return await this.foodRepository
+      .createQueryBuilder('food')
+      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .where('food.isTest = true')
+      .orderBy('RAND()')
+      .limit(3)
+      .getMany();
   }
 
   async findTestFoods(): Promise<Food[]> {


### PR DESCRIPTION
✅ Closes: #50

# 주제

- 음식 리뷰 화면 음식 리스트 반환 API 구현

# 작업 완료 내용 (자세히 작성)

- 음식 리뷰 화면에서 리뷰 할 음식을 랜덤으로 3개 가져 옵니다.
<img width="558" alt="스크린샷 2021-10-27 오후 9 08 34" src="https://user-images.githubusercontent.com/37958836/139062676-bbc71ee9-2ca7-43e6-ae37-40704afc8a00.png">
<img width="616" alt="스크린샷 2021-10-27 오후 9 08 55" src="https://user-images.githubusercontent.com/37958836/139062718-5e352b62-b822-42e3-9bb7-7477b6c573bd.png">


# 관련 이슈 번호

- #50 

# 미작업 내용

-

# 주의사항

- [ ]
