### PR TITLE
Fix #60 사용자/음식 ID값을 이용한 리뷰 조회 API 수정

### DIFF
--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -81,10 +81,10 @@ export class ReviewController {
     description: '해당하는 리뷰에 대한 정보를 받는다.',
     type: [OmitType(Review, [])],
   })
-  findReviewsByUser(
+  findReviewsByUserId(
     @Param() params,
   ): Promise<(Omit<Review, 'hotLevel'> & { hotLevel: HOT_LEVEL })[]> {
-    return this.reviewService.findReviewsByUser(params.userId);
+    return this.reviewService.findReviewsByUserId(params.userId);
   }
 
   @Get('food/count/:foodId')

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -76,7 +76,7 @@ export class ReviewService {
     };
   }
 
-  async findReviewByfoodId(foodId: number) {
+  async findReviewByfoodId(foodId: string) {
     return this.reviewRepository
       .createQueryBuilder('review')
       .leftJoin('review.food', 'food')
@@ -102,7 +102,7 @@ export class ReviewService {
       );
   }
 
-  async findReviewsByUser(userId: number) {
+  async findReviewsByUserId(userId: string) {
     return this.reviewRepository
       .createQueryBuilder('review')
       .leftJoinAndSelect('review.food', 'food')


### PR DESCRIPTION
✅ Closes: #60

# 주제

- 사용자/음식 ID값을 이용한 리뷰 조회 API 수정

# 작업 완료 내용 (자세히 작성)

- `review.service.ts`수정
  - `foodId`값 Type number -> string 변경 
  - `userId`값 Type number -> string 변경

# 관련 이슈 번호

- #60 

# 미작업 내용

- x

# 주의사항

- [ ]
