### PR TITLE
Feat #64 foodId로 음식 데이터를 가져오는 API 

### DIFF
--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -1,13 +1,16 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { FoodService } from './food.service';
 import { Food } from './entities/food.entity';
 import {
   ApiBody,
   ApiCreatedResponse,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
+  OmitType,
+  PickType,
 } from '@nestjs/swagger';
 import { CreateFoodDto } from './dto/create-food.dto';
 import { FindFoodsQueryDto } from './dto/find-foods-query.dto';
@@ -34,6 +37,22 @@ export class FoodController {
   @ApiResponse({ description: '음식 리스트', type: FindFoodDto })
   async findFoods(@Query() params: FindFoodsQueryDto): Promise<FindFoodDto[]> {
     return this.foodService.findFoods(params);
+  }
+
+  @Get(':foodId')
+  @ApiOperation({
+    summary: '음식id 기반으로 해당 음식의 데이터를 가져오는 API',
+    description: '음식 id가 주어진다. 해당 음식의 데이터를 가져온다.',
+  })
+  @ApiParam({ name: '음식 id', type: String })
+  @ApiResponse({
+    description: '음식 리스트',
+    type: PickType(FindFoodDto, ['id', 'imageUrl', 'name', 'subName']),
+  })
+  async findFoodByFoodId(
+    @Param() param: { foodId: string },
+  ): Promise<Omit<FindFoodDto, 'hotLevel'>> {
+    return this.foodService.findFoodByFoodId(param.foodId);
   }
 
   @Get('/reviews')

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -182,4 +182,20 @@ export class FoodService {
       .limit(1)
       .getOne();
   }
+
+  async findFoodByFoodId(
+    foodId: string,
+  ): Promise<Omit<FindFoodDto, 'hotLevel'>> {
+    return this.foodRepository
+      .createQueryBuilder('food')
+      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .where('food.id = :foodId', { foodId })
+      .getOne()
+      .then(({ id, name, subName, imageUrl }) => ({
+        id,
+        name,
+        subName,
+        imageUrl,
+      }));
+  }
 }


### PR DESCRIPTION
# 주제

- foodId로 음식 데이터를 가져오는 API 

# 작업 완료 내용 (자세히 작성)
`GET /food/:foodId`
- foodId를 기반으로 id, name, subName, imageUrl을 가져옵니다.
Response
```json
{
    "data": {
        "id": "1",
        "name": "떡볶이",
        "subName": "",
        "imageUrl": null
    },
    "statusCode": 200,
    "message": "Success"
}
```

# 관련 이슈 번호

- closes #64 

# 미작업 내용

-

# 주의사항

- [ ]
