### PR TITLE
Fix #66 TasteTag가 DB에 적용되지 않는 문제 해결

### DIFF
--- a/src/review/dto/create-review.dto.ts
+++ b/src/review/dto/create-review.dto.ts
@@ -1,5 +1,6 @@
 import { IsString, isEnum, IsEnum } from 'class-validator';
 import { HOT_LEVEL } from 'src/common/enums/hot-level';
+import { TASTE_TAG } from 'src/common/enums/taste-tag';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateReviewDto {
@@ -18,7 +19,7 @@ export class CreateReviewDto {
   @ApiProperty({ description: '음식 id' })
   foodId: string;
 
-  @IsString({ each: true })
-  @ApiProperty({ description: '음식 태그 id' })
-  tagIds: string[];
+  @IsEnum(TASTE_TAG, {each: true})
+  @ApiProperty({ description: "음식 태그 ex) '얼얼한', '칼칼한', '매콤달콤한', '알싸한', '얼큰한', '개운한'", })
+  tagIds: TASTE_TAG[];
 }

--- a/src/review/dto/create-review.dto.ts
+++ b/src/review/dto/create-review.dto.ts
@@ -21,5 +21,5 @@ export class CreateReviewDto {
 
   @IsEnum(TASTE_TAG, {each: true})
   @ApiProperty({ description: "음식 태그 ex) '얼얼한', '칼칼한', '매콤달콤한', '알싸한', '얼큰한', '개운한'", })
-  tagIds: TASTE_TAG[];
+  tags: TASTE_TAG[];
 }

--- a/src/review/dto/create-reviews.dto.ts
+++ b/src/review/dto/create-reviews.dto.ts
@@ -1,6 +1,7 @@
 import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
 import { IsString, IsArray, IsEnum } from 'class-validator';
 import { HOT_LEVEL } from 'src/common/enums/hot-level';
+import { TASTE_TAG } from 'src/common/enums/taste-tag';
 
 export class ReviewDto {
   @IsEnum(HOT_LEVEL)
@@ -14,9 +15,9 @@ export class ReviewDto {
   @ApiProperty({ description: '음식 id' })
   foodId: string;
 
-  @IsString({ each: true })
-  @ApiProperty({ description: '음식 맛평가 태그 id' })
-  tagIds: string[];
+  @IsEnum(TASTE_TAG, {each: true})
+  @ApiProperty({ description: "음식 태그 ex) '얼얼한', '칼칼한', '매콤달콤한', '알싸한', '얼큰한', '개운한'", })
+  tagIds: TASTE_TAG[];
 }
 
 export class CreateReviewsDto {

--- a/src/review/dto/create-reviews.dto.ts
+++ b/src/review/dto/create-reviews.dto.ts
@@ -17,7 +17,7 @@ export class ReviewDto {
 
   @IsEnum(TASTE_TAG, {each: true})
   @ApiProperty({ description: "음식 태그 ex) '얼얼한', '칼칼한', '매콤달콤한', '알싸한', '얼큰한', '개운한'", })
-  tagIds: TASTE_TAG[];
+  tags: TASTE_TAG[];
 }
 
 export class CreateReviewsDto {

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -17,7 +17,7 @@ import {
   HotLevelCountType,
   TasteTagCountType,
 } from './dto/find-review-count.dto';
-import { produceTasteTagString } from './utils/produceTasteTag';
+import { produceTasteTagString, produceTasteTagId } from './utils/produceTasteTag';
 import { HOT_LEVEL } from 'src/common/enums/hot-level';
 import { TASTE_TAG } from 'src/common/enums/taste-tag';
 
@@ -32,14 +32,15 @@ export class ReviewService {
     const { hotLevel, userId, foodId, tagIds } = reviewDetails;
     const review = new Review();
     const hotLevelId = produceHotLevelId(hotLevel);
-
     review.hotLevel = await getRepository(FoodLevel).findOne(hotLevelId);
     review.user = await getRepository(User).findOne(userId);
     review.food = await getRepository(Food).findOne(foodId);
     review.tasteReviews = await Promise.all(
-      tagIds.map(async (tagid) => {
-        const tag = getRepository(TasteTag).findOne(tagid);
-        return tag;
+      tagIds.map(async (tag) => {
+        const tagid = produceTasteTagId(tag)
+        const Tag = getRepository(TasteTag).findOne(tagid);
+        console.log(tagid)
+        return Tag;
       }),
     );
 

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -39,7 +39,6 @@ export class ReviewService {
       tagIds.map(async (tag) => {
         const tagid = produceTasteTagId(tag)
         const Tag = getRepository(TasteTag).findOne(tagid);
-        console.log(tagid)
         return Tag;
       }),
     );
@@ -63,9 +62,10 @@ export class ReviewService {
       review.food = await getRepository(Food).findOne(foodId);
       review.hotLevel = await getRepository(FoodLevel).findOne(hotLevelId);
       review.tasteReviews = await Promise.all(
-        tagIds.map(async (tagid) => {
-          const tag = getRepository(TasteTag).findOne(tagid);
-          return tag;
+        tagIds.map(async (tag) => {
+          const tagid = produceTasteTagId(tag)
+          const Tag = getRepository(TasteTag).findOne(tagid);
+          return Tag;
         }),
       );
       return this.reviewRepository.save(review);

--- a/src/review/utils/produceTasteTag.ts
+++ b/src/review/utils/produceTasteTag.ts
@@ -16,3 +16,20 @@ export const produceTasteTagString = (tasteTagId: string): TASTE_TAG => {
       return TASTE_TAG.GAEUN;
   }
 };
+
+export const produceTasteTagId = (tasteTagId: TASTE_TAG): string => {
+  switch (tasteTagId) {
+    case TASTE_TAG.EOLEOL:
+      return '1';
+    case TASTE_TAG.KALKAL:
+      return '2';
+    case TASTE_TAG.MAECOMDALCOM:
+      return '3';
+    case TASTE_TAG.ALSSA:
+      return '4';
+    case TASTE_TAG.EOLKEUN:
+      return '5';
+    default:
+      return '6';
+  }
+};


### PR DESCRIPTION
# 주제

- TasteTag가 DB에 적용되지 않는 문제를 해결함

# 작업 완료 내용 (자세히 작성)

- TasteTag가 제대로 저장되지 않은 것은 TASTE_TAG enum처리가 제대로 되어있지 않아서였습니다.
- util에 TasteTag를 id로 변환하는 함수를 추가하고, dto를 수정했습니다.
- service또한 이를 처리할 수 있도록 수정했습니다.

# 관련 이슈 번호

- #66 

# 미작업 내용

- 쿼리빌더로 리팩토링하는 것의 경우, manytomany관계를 구현하기가 곤란하고 코드가 너무 길어져 일단 보류했습니다.
- 특히 review table의 경우 고유한 id값을 갖지 않아 참조하는 과정에서 foreign key constraint fails 에러가 발생해 일단 typeorm코드로 업로드 합니다.

# 주의사항

- [ ]
