### PR TITLE
refactor: 💡 매운 음식 추천 탭에서 사용자 레벨에 해당하는 음식만 추천 해주도록 수정

### DIFF
--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -94,7 +94,7 @@ export class FoodController {
     summary: '음식 랜덤 추천 API',
     description: '음식을 랜덤 추천합니다.',
   })
-  @ApiQuery({ name: 'user', type: String, description: '사용자 ID' })
+  @ApiQuery({ name: 'userId', type: String, description: '사용자 ID' })
   @ApiResponse({ description: '레벨별 음식 정보', type: RandomFoodDto })
   async findRandomFood(
     @Query() param: { userId: string },

--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -94,9 +94,12 @@ export class FoodController {
     summary: '음식 랜덤 추천 API',
     description: '음식을 랜덤 추천합니다.',
   })
-  @ApiCreatedResponse({ description: '레벨별 음식 정보', type: RandomFoodDto })
-  async findRandomFood(): Promise<RandomFoodDto> {
-    return this.foodService.findRandomFoods();
+  @ApiQuery({ name: 'user', type: String, description: '사용자 ID' })
+  @ApiResponse({ description: '레벨별 음식 정보', type: RandomFoodDto })
+  async findRandomFood(
+    @Query() param: { userId: string },
+  ): Promise<RandomFoodDto> {
+    return this.foodService.findRandomFoods(param.userId);
   }
 
   @Get(':foodId')

--- a/src/food/food.module.ts
+++ b/src/food/food.module.ts
@@ -6,9 +6,20 @@ import { Food } from './entities/food.entity';
 import { Restaurant } from './entities/restaurant.entity';
 import { FoodLevel } from './entities/food_level.entity';
 import { Category } from './entities/category.entity';
+import { User } from 'src/user/entities/user.entity';
+import { UserLevel } from 'src/user/entities/user_level.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Food, Restaurant, FoodLevel, Category])],
+  imports: [
+    TypeOrmModule.forFeature([
+      Food,
+      Restaurant,
+      FoodLevel,
+      Category,
+      User,
+      UserLevel,
+    ]),
+  ],
   controllers: [FoodController],
   providers: [FoodService],
 })

--- a/src/food/food.module.ts
+++ b/src/food/food.module.ts
@@ -7,18 +7,10 @@ import { Restaurant } from './entities/restaurant.entity';
 import { FoodLevel } from './entities/food_level.entity';
 import { Category } from './entities/category.entity';
 import { User } from 'src/user/entities/user.entity';
-import { UserLevel } from 'src/user/entities/user_level.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([
-      Food,
-      Restaurant,
-      FoodLevel,
-      Category,
-      User,
-      UserLevel,
-    ]),
+    TypeOrmModule.forFeature([Food, Restaurant, FoodLevel, Category, User]),
   ],
   controllers: [FoodController],
   providers: [FoodService],

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -193,6 +193,10 @@ export class FoodService {
       .where('user.id = :userId', { userId })
       .getOne();
 
+    if (userlevel.id === '5') {
+      userlevel.id = '4';
+    }
+
     return await this.foodRepository
       .createQueryBuilder('food')
       .leftJoinAndSelect('food.foodLevel', 'foodLevel')

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { produceHotLevelId } from 'src/review/utils/produce-hot-level';
 import { User } from 'src/user/entities/user.entity';
-import { UserLevel } from 'src/user/entities/user_level.entity';
-import { Not, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { CreateFoodDto } from './dto/create-food.dto';
 import { FindFoodDto, RandomFoodDto } from './dto/find-food.dto';
 import { FindFoodsQueryDto } from './dto/find-foods-query.dto';
@@ -27,15 +26,11 @@ export class FoodService {
 
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-
-    @InjectRepository(UserLevel)
-    private readonly userLevelRepository: Repository<UserLevel>,
   ) {
     this.foodRepository = foodRepository;
     this.foodLevelRepository = foodLevelRepository;
     this.categoryRepository = categoryRepository;
     this.userRepository = userRepository;
-    this.userLevelRepository = userLevelRepository;
   }
 
   async findReviewFoods(): Promise<Food[]> {
@@ -203,7 +198,6 @@ export class FoodService {
       .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
       .where('food.foodLevel = :foodLevel', { foodLevel: userlevel.id })
       .orderBy('RAND()')
-      .limit(1)
       .getOne();
   }
 


### PR DESCRIPTION
✅ Closes: #71

# 주제

- 랜덤 음식 추천 방식 사용자 레벨에 맞는 음식을 추천 해주도록 수정합니다.

# 작업 완료 내용 (자세히 작성)

- `food/random` API 수정
    - `userId`를 query param으로 받아 해당 레벨에 맞는 음식을 추천 해주도록 수정

# 관련 이슈 번호

- #71 

# 미작업 내용

-

# 주의사항

- [ ] `query param`이 추가 되어 배포 후 Front분들께 수정 사항 공유
