### PR TITLE
Refactor #76 Production에서만 에러를 Slack에 로깅하도록 수정

### DIFF
--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -15,21 +15,20 @@ export class HttpExceptionFilter implements ExceptionFilter<HttpException> {
     const request = ctx.getRequest();
     const statusCode = exception.getStatus();
 
-    // Log on slack
-    this.httpService
-      .post(process.env.SLACK_WEBHOOK, {
-        text: `
+    // Log on slack only in production mode
+    if (process.env.NODE_ENV === 'production') {
+      this.httpService
+        .post(process.env.SLACK_WEBHOOK, {
+          text: `
           🚨 *사용자 오류 발생* 🚨
 
             *✔️ 에러 명:* ${exception.name}
             *✔️ 메세지:* ${exception.message}
             *✔️ URL:* ${request.url}
-
-            *✔️ 스택 확인*
-                ${exception.stack}
           `,
-      })
-      .subscribe();
+        })
+        .subscribe();
+    }
 
     response.status(200).json({
       statusCode,

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -15,7 +15,7 @@ export class HttpExceptionFilter implements ExceptionFilter<HttpException> {
     const request = ctx.getRequest();
     const statusCode = exception.getStatus();
 
-    // Log on slack only in production mode
+    // production에서만 에러 내용을 슬랙에 로깅함
     if (process.env.NODE_ENV === 'production') {
       this.httpService
         .post(process.env.SLACK_WEBHOOK, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,17 +3,22 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
-async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
-    cors: {
-      origin: [
+const origin =
+  process.env.NODE_ENV === 'development'
+    ? [
         'http://localhost:3000',
         'http://127.0.0.1:3000',
         'https://ohmebddeng.kr',
         'https://www.ohmebddeng.kr',
         'https://ohmebddeng-frontend.vercel.app',
         'https://ohmebddeng-frontend-git-develop-waterplease.vercel.app',
-      ],
+      ]
+    : ['https://ohmebddeng.kr', 'https://www.ohmebddeng.kr'];
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    cors: {
+      origin,
       credentials: true,
     },
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,11 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
+/**
+ * dev/prod에 따라 access-control-allow-origin을 다르게 적용함
+ * DEV: localhost, dev 배포된 front-end app, prod 배포된 front-end app
+ * PROD: ohmebddeng.kr, www.ohmebddeng.kr
+ */
 const origin =
   process.env.NODE_ENV === 'development'
     ? [


### PR DESCRIPTION
# 주제

- Production에서만 발생한 에러를 slack에 로깅합니다.
- DEV/PROD 서버가 2개 생겼으므로 CORS 부분을 수정합니다.

# 작업 완료 내용 (자세히 작성)

- Production에서 발생한 에러는 Slack 봇이 알림을 줍니다.
- allow-origin을 수정해 production에서는 반드시 production에 배포된 프론트엔드 앱만 요청이 가능하게 합니다.
- DEV 서버는 localhost, dev앱, prod앱 모두 요청을 보낼 수 있습니다.

# 관련 이슈 번호

- closes #76 

# 미작업 내용

-

# 주의사항

- [ ]
