### PR TITLE
Refactor #84 음식 로고와 관련된 이미지 칼럼 추가 및 음식 리뷰 API 수정

### DIFF
--- a/src/food/dto/find-food.dto.ts
+++ b/src/food/dto/find-food.dto.ts
@@ -21,7 +21,7 @@ export class FindFoodDto {
 
   @IsString()
   @ApiProperty({ description: '음식 로고 이미지', type: String || null })
-  logoImageUrl: string | null;
+  logoImageUrl?: string | null;
 
   @IsEnum(HOT_LEVEL)
   @ApiProperty({ description: '음식의 맵기 레벨', enum: HOT_LEVEL })

--- a/src/food/dto/find-food.dto.ts
+++ b/src/food/dto/find-food.dto.ts
@@ -47,5 +47,5 @@ export class RandomFoodDto {
 
   @IsString()
   @ApiProperty({ description: '음식 로고 이미지', type: String || null })
-  logoImageUrl: string | null;
+  logoImageUrl?: string | null;
 }

--- a/src/food/dto/find-food.dto.ts
+++ b/src/food/dto/find-food.dto.ts
@@ -19,6 +19,10 @@ export class FindFoodDto {
   @ApiProperty({ description: '음식 이미지', type: String || null })
   imageUrl: string | null;
 
+  @IsString()
+  @ApiProperty({ description: '음식 로고 이미지', type: String || null })
+  logoImageUrl: string | null;
+
   @IsEnum(HOT_LEVEL)
   @ApiProperty({ description: '음식의 맵기 레벨', enum: HOT_LEVEL })
   hotLevel: HOT_LEVEL;
@@ -40,4 +44,8 @@ export class RandomFoodDto {
   @IsString()
   @ApiProperty({ description: '음식 이미지', type: String || null })
   imageUrl: string | null;
+
+  @IsString()
+  @ApiProperty({ description: '음식 로고 이미지', type: String || null })
+  logoImageUrl: string | null;
 }

--- a/src/food/entities/food.entity.ts
+++ b/src/food/entities/food.entity.ts
@@ -65,6 +65,14 @@ export class Food {
   @ApiProperty({ description: '음식 사진 URL', type: String, nullable: true })
   imageUrl: string;
 
+  @Column({ nullable: true })
+  @ApiProperty({
+    description: '음식 로고 사진 URL',
+    type: String,
+    nullable: true,
+  })
+  logoImageUrl: string;
+
   // 하나의 음식이 여러 카테고리, [ex) 떡볶이 => 한식, 분식]에 속할 수 있다고 가정
   @ManyToMany(() => Category, { nullable: false })
   @JoinTable({ name: 'food_category' })

--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -1,6 +1,4 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
-import { FoodService } from './food.service';
-import { Food } from './entities/food.entity';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -9,13 +7,14 @@ import {
   ApiQuery,
   ApiResponse,
   ApiTags,
-  OmitType,
   PickType,
 } from '@nestjs/swagger';
-import { CreateFoodDto } from './dto/create-food.dto';
-import { FindFoodsQueryDto } from './dto/find-foods-query.dto';
-import { FindFoodDto, RandomFoodDto } from './dto/find-food.dto';
-import { FindUserLevelFoodDto } from './dto/find-userLevel-food.dto';
+import { FoodService } from '@food/food.service';
+import { Food } from '@food/entities/food.entity';
+import { CreateFoodDto } from '@food/dto/create-food.dto';
+import { FindFoodsQueryDto } from '@food/dto/find-foods-query.dto';
+import { FindFoodDto, RandomFoodDto } from '@food/dto/find-food.dto';
+import { FindUserLevelFoodDto } from '@food/dto/find-userLevel-food.dto';
 
 @Controller('food')
 @ApiTags('음식 API')
@@ -45,7 +44,7 @@ export class FoodController {
     description: '리뷰 할 음식 List을 가져온다.',
   })
   @ApiCreatedResponse({ description: '음식 list', type: Food })
-  async reviewFoodList(): Promise<Food[]> {
+  async reviewFoodList(): Promise<Food> {
     return this.foodService.findReviewFoods();
   }
 
@@ -110,7 +109,13 @@ export class FoodController {
   @ApiParam({ name: '음식 id', type: String })
   @ApiResponse({
     description: '음식 리스트',
-    type: PickType(FindFoodDto, ['id', 'imageUrl', 'name', 'subName']),
+    type: PickType(FindFoodDto, [
+      'id',
+      'imageUrl',
+      'logoImageUrl',
+      'name',
+      'subName',
+    ]),
   })
   async findFoodByFoodId(
     @Param() param: { foodId: string },

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -122,7 +122,9 @@ export class FoodService {
    * @param param userId?: string, category?: string, size?: string, sort?: SORT, hotLevel?: HOT_LEVEL
    * @returns id, name, subName, imageUrl, logoImageUrl, hotLevel로 이루어진 객체의 배열
    */
-  async findFoods(param: FindFoodsQueryDto): Promise<FindFoodDto[]> {
+  async findFoods(
+    param: FindFoodsQueryDto,
+  ): Promise<Omit<FindFoodDto[], 'logoImageUrl'>> {
     const { category, hotLevel, size: providedSize, sort } = param;
     const size = providedSize ? Number(providedSize) : 10; // default size = 10
 

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -33,20 +33,33 @@ export class FoodService {
     this.userRepository = userRepository;
   }
 
-  async findReviewFoods(): Promise<Food[]> {
-    return await this.foodRepository
+  async findReviewFoods(): Promise<Food> {
+    const foods: Food = await this.foodRepository
       .createQueryBuilder('food')
-      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .select([
+        'food.id',
+        'food.name',
+        'food.subName',
+        'food.imageUrl',
+        'food.logoImageUrl',
+      ])
       .where('food.isTest = true')
       .orderBy('RAND()')
-      .limit(3)
-      .getMany();
+      .getOne();
+
+    return foods;
   }
 
   async findTestFoods(): Promise<Food[]> {
     return await this.foodRepository
       .createQueryBuilder('food')
-      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .select([
+        'food.id',
+        'food.name',
+        'food.subName',
+        'food.imageUrl',
+        'food.logoImageUrl',
+      ])
       .where('food.isTest = true')
       .orderBy('RAND()')
       .getMany();
@@ -107,7 +120,7 @@ export class FoodService {
    * 경우에 따라서 user의 맵레벨과 상관없이 특정 카테고리의 모든 음식만 가져오는 API가 필요할 수도 있고,
    * 전체 음식 리스트를 가져오고 싶은 경우도 있을 수 있기 때문입니다.
    * @param param userId?: string, category?: string, size?: string, sort?: SORT, hotLevel?: HOT_LEVEL
-   * @returns id, name, subName, imageUrl, hotLevel로 이루어진 객체의 배열
+   * @returns id, name, subName, imageUrl, logoImageUrl, hotLevel로 이루어진 객체의 배열
    */
   async findFoods(param: FindFoodsQueryDto): Promise<FindFoodDto[]> {
     const { category, hotLevel, size: providedSize, sort } = param;
@@ -173,7 +186,13 @@ export class FoodService {
     return await this.foodRepository
       .createQueryBuilder('food')
       .leftJoinAndSelect('food.foodLevel', 'foodLevel')
-      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .select([
+        'food.id',
+        'food.name',
+        'food.subName',
+        'food.imageUrl',
+        'food.logoImageUrl',
+      ])
       .where('food.foodLevel = :foodLevel', { foodLevel })
       .orderBy('RAND()')
       .limit(3)
@@ -195,7 +214,13 @@ export class FoodService {
     return await this.foodRepository
       .createQueryBuilder('food')
       .leftJoinAndSelect('food.foodLevel', 'foodLevel')
-      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .select([
+        'food.id',
+        'food.name',
+        'food.subName',
+        'food.imageUrl',
+        'food.logoImageUrl',
+      ])
       .where('food.foodLevel = :foodLevel', { foodLevel: userlevel.id })
       .orderBy('RAND()')
       .getOne();
@@ -206,14 +231,21 @@ export class FoodService {
   ): Promise<Omit<FindFoodDto, 'hotLevel'>> {
     return this.foodRepository
       .createQueryBuilder('food')
-      .select(['food.id', 'food.name', 'food.subName', 'food.imageUrl'])
+      .select([
+        'food.id',
+        'food.name',
+        'food.subName',
+        'food.imageUrl',
+        'food.logoImageUrl',
+      ])
       .where('food.id = :foodId', { foodId })
       .getOne()
-      .then(({ id, name, subName, imageUrl }) => ({
+      .then(({ id, name, subName, imageUrl, logoImageUrl }) => ({
         id,
         name,
         subName,
         imageUrl,
+        logoImageUrl,
       }));
   }
 }

--- a/src/food/utils/produceFindFoodDto.ts
+++ b/src/food/utils/produceFindFoodDto.ts
@@ -5,12 +5,14 @@ import { Food } from '../entities/food.entity';
 /**
  * Food 배열을 받아 FindFoodDto 배열을 반환하는 함수. DB에서 가져온 데이터를 클라이언트에서 쓰기 쉽게 가공하는 역할을 함.
  * @param foods Food entity 배열
- * @returns id: 음식id, name: 음식명, subName: 음식 맛, imageUrl: 음식 이미지, hotLevel: 음식 맵기 레벨 객체로 이루어진 배열
+ * @returns id: 음식id, name: 음식명, subName: 음식 맛, imageUrl: 음식 이미지, logoImageUrl: 음식 로고 이미지, hotLevel: 음식 맵기 레벨 객체로 이루어진 배열
  */
 export const produceFindFoodDto = (foods: Food[]): FindFoodDto[] => {
-  return foods.map(({ id, name, subName, imageUrl, foodLevel }) => {
-    const hotLevel = produceHotLevelString(foodLevel ? foodLevel.id : '1');
+  return foods.map(
+    ({ id, name, subName, imageUrl, logoImageUrl, foodLevel }) => {
+      const hotLevel = produceHotLevelString(foodLevel ? foodLevel.id : '1');
 
-    return { id, name, subName, imageUrl, hotLevel };
-  });
+      return { id, name, subName, imageUrl, logoImageUrl, hotLevel };
+    },
+  );
 };

--- a/src/food/utils/produceFindFoodDto.ts
+++ b/src/food/utils/produceFindFoodDto.ts
@@ -5,14 +5,12 @@ import { Food } from '../entities/food.entity';
 /**
  * Food 배열을 받아 FindFoodDto 배열을 반환하는 함수. DB에서 가져온 데이터를 클라이언트에서 쓰기 쉽게 가공하는 역할을 함.
  * @param foods Food entity 배열
- * @returns id: 음식id, name: 음식명, subName: 음식 맛, imageUrl: 음식 이미지, logoImageUrl: 음식 로고 이미지, hotLevel: 음식 맵기 레벨 객체로 이루어진 배열
+ * @returns id: 음식id, name: 음식명, subName: 음식 맛, imageUrl: 음식 이미지, hotLevel: 음식 맵기 레벨 객체로 이루어진 배열
  */
 export const produceFindFoodDto = (foods: Food[]): FindFoodDto[] => {
-  return foods.map(
-    ({ id, name, subName, imageUrl, logoImageUrl, foodLevel }) => {
-      const hotLevel = produceHotLevelString(foodLevel ? foodLevel.id : '1');
+  return foods.map(({ id, name, subName, imageUrl, foodLevel }) => {
+    const hotLevel = produceHotLevelString(foodLevel ? foodLevel.id : '1');
 
-      return { id, name, subName, imageUrl, logoImageUrl, hotLevel };
-    },
-  );
+    return { id, name, subName, imageUrl, hotLevel };
+  });
 };


### PR DESCRIPTION
# 주제
- 음식 로고와 관련된 이미지 칼럼 추가 및 음식 리뷰 API 수정합니다.

# 작업 완료 내용 (자세히 작성)
- `food` 테이블에 음식 로고와 관련된 칼럼 값을 추가합니다.
   - `logoImageUrl` 칼럼 값 추가
- `/food/reviews` API 수정
   - 기존 레벨 테스트 진행 후 리뷰를 작성하는 음식 값을 3개에서 1개로 변경됨에 따라 해당 로직을 수정
- `logoImageUrl`칼럼 추가로 인한 API Return 값 수정

# 관련 이슈 번호

- ✅ Close #84 

# 미작업 내용

- x

# 주의사항

- [ ]
