### PR TITLE
Refactor #87 User Controller에서 swagger 코드를 제거하고, nest-cli가 자동생성하게 합니다

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,4 +1,17 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "classValidatorShim": true,
+          "introspectComments": true,
+          "dtoKeyOfComment": true,
+          "controllerKeyOfComment": true
+        }
+      }
+    ]
+  }
 }

--- a/src/user/dto/find-user.dto.ts
+++ b/src/user/dto/find-user.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { IsNumberString } from 'class-validator';
 import { Review } from 'src/review/entities/review.entity';
 import { User } from '../entities/user.entity';
 
@@ -22,7 +23,7 @@ class UserLevelDto {
   details: string[];
 }
 
-export class FindUserDto
+export class FindUserResponseDto
   implements Omit<User, 'userLevel' | 'isDeleted' | 'role'>
 {
   @ApiProperty({ description: 'id' })
@@ -72,4 +73,10 @@ export class FindUserDto
 
   @ApiProperty({ description: 'reviews' })
   reviews: Review[];
+}
+
+export class FindUserRequestDto {
+  @ApiProperty({ description: '사용자 id. 숫자로된 string' })
+  @IsNumberString()
+  userId: string;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -24,12 +24,14 @@ export class UserController {
 
   // 익명 사용자 ID 발급
   @Get('anonymous')
+  @ApiOperation({ summary: '익명 사용자를 생성하는 API' })
   async createAnonymousUser(): Promise<FindAnonymousUserDto> {
     return this.userService.createAnonymousUser();
   }
 
   // 서비스를 사용한 사용자 수 조회
   @Get('count')
+  @ApiOperation({ summary: '총 사용자 수를 조회하는 API' })
   async findUserCount(
     @Query() param: FindUserCountQueryDto,
   ): Promise<FindUserCountDto> {
@@ -38,6 +40,7 @@ export class UserController {
 
   // 익명 사용자 ID 기반 사용자 정보 조회
   @Get(':userId')
+  @ApiOperation({ summary: '특정 사용자의 정보를 가져오는 API' })
   async findUser(
     @Param() params: FindUserRequestDto,
   ): Promise<FindUserResponseDto | Omit<FindUserResponseDto, 'userLevel'>> {
@@ -46,6 +49,7 @@ export class UserController {
 
   // 사용자 레벨 테스트 제출
   @Post('level')
+  @ApiOperation({ summary: '사용자의 Level Test 결과를 생성/업데이트하는 API' })
   async updateUserLevel(
     @Body() params: updateUserLevelDto,
   ): Promise<FindUserLevelDto> {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -8,13 +8,15 @@ import {
   ApiBody,
   ApiOperation,
   ApiParam,
+  ApiProperty,
   ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { FindAnonymousUserDto } from './dto/find-anonymous-user.dto';
 import { FindUserCountQueryDto } from './dto/find-user-count-query.dto';
-import { FindUserDto } from './dto/find-user.dto';
+import { FindUserRequestDto, FindUserResponseDto } from './dto/find-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 @Controller('user')
 @ApiTags('사용자 API')
 export class UserController {
@@ -22,34 +24,12 @@ export class UserController {
 
   // 익명 사용자 ID 발급
   @Get('anonymous')
-  @ApiOperation({
-    summary: '익명 사용자 ID 발급 API',
-    description: '익명 사용자 ID를 생성하고 반환한다',
-  })
-  @ApiResponse({
-    description: '익명사용자 ID를 발급받는다',
-    type: FindAnonymousUserDto,
-  })
   async createAnonymousUser(): Promise<FindAnonymousUserDto> {
     return this.userService.createAnonymousUser();
   }
 
   // 서비스를 사용한 사용자 수 조회
   @Get('count')
-  @ApiOperation({
-    summary: '사용자 수 조회 API',
-    description: '총 사용자 수 혹은 레벨테스트를 마친 사용자 수를 조회한다',
-  })
-  @ApiQuery({
-    name: 'levelTestedOnly',
-    type: FindUserCountQueryDto,
-    description: '레벨테스트를 마친 사용자 수만 조회할지 여부',
-  })
-  @ApiResponse({
-    description:
-      'levelTestedOnly === true 이면 레벨테스트를 마친 사용자 수를, 이외의 경우에는 총 사용자 수를 받는다',
-    type: FindUserCountDto,
-  })
   async findUserCount(
     @Query() param: FindUserCountQueryDto,
   ): Promise<FindUserCountDto> {
@@ -58,32 +38,14 @@ export class UserController {
 
   // 익명 사용자 ID 기반 사용자 정보 조회
   @Get(':userId')
-  @ApiOperation({
-    summary: '사용자 ID 기반 사용자 정보 조회 API',
-    description: '사용자 ID를 기반으로 사용자를 찾아 반환한다',
-  })
-  @ApiParam({ name: '사용자ID', type: String })
-  @ApiResponse({
-    description: '사용자에 대한 정보를 받는다',
-    type: FindUserDto,
-  })
   async findUser(
-    @Param() params,
-  ): Promise<FindUserDto | Omit<FindUserDto, 'userLevel'>> {
+    @Param() params: FindUserRequestDto,
+  ): Promise<FindUserResponseDto | Omit<FindUserResponseDto, 'userLevel'>> {
     return this.userService.findUser(params.userId);
   }
+
   // 사용자 레벨 테스트 제출
   @Post('level')
-  @ApiOperation({
-    summary: '사용자 레벨테스트 결과 제출 API',
-    description: `레벨테스트 응답결과를 제출하고 사용자의 레벨을 받는다. (참고) hotLevel =  "냠냠" | "쓰읍" | "씁하" | "헥헥" | "모름"`,
-  })
-  @ApiBody({ type: updateUserLevelDto })
-  @ApiResponse({
-    description: '사용자의 ID와 레벨을 받는다',
-    status: 200,
-    type: FindUserLevelDto,
-  })
   async updateUserLevel(
     @Body() params: updateUserLevelDto,
   ): Promise<FindUserLevelDto> {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -19,7 +19,7 @@ interface IFoodLevel {
 import { FindAnonymousUserDto } from './dto/find-anonymous-user.dto';
 import { FindUserCountDto } from './dto/find-user-count.dto';
 import { FindUserCountQueryDto } from './dto/find-user-count-query.dto';
-import { FindUserDto } from './dto/find-user.dto';
+import { FindUserResponseDto } from './dto/find-user.dto';
 @Injectable()
 export class UserService {
   constructor(
@@ -44,7 +44,7 @@ export class UserService {
    */
   async findUser(
     userId: string,
-  ): Promise<FindUserDto | Omit<FindUserDto, 'userLevel'>> {
+  ): Promise<FindUserResponseDto | Omit<FindUserResponseDto, 'userLevel'>> {
     const query = this.userRepository
       .createQueryBuilder('user')
       .leftJoinAndSelect('user.userLevel', 'userLevel')


### PR DESCRIPTION
# 주제

- nest-cli를 이용해 Swagger를 자동생성하게 합니다.
- User Controller에서 코드 복잡도를 증가시키던 Swagger 선언들을 제거합니다.

# 작업 완료 내용 (자세히 작성)

| Example Value | Schema |
| --- | --- |
| ![스크린샷 2021-11-22 오후 12 25 35](https://user-images.githubusercontent.com/33085082/142796503-e2cd5422-f8c0-4673-be3f-c2862fbf7ccd.png) | ![스크린샷 2021-11-22 오후 12 26 39](https://user-images.githubusercontent.com/33085082/142796567-6e1fcd76-1c73-49a5-a000-88d2a1e09f51.png) |


설명이 조금 덜 자세해졌지만, 지금도 충분하지 않나 생각합니다.

- nest-cli 설정
- user controller 리팩토링
- FindUserDto를 FindUserRequestDto, FindUserResponseDto로 분리(요청이 오는 dto, 응답이 가는 dto 분리)

# 관련 이슈 번호

- closes #87 

# 미작업 내용

-

# 주의사항

- [ ] DTO 파일들은 이전처럼 `ApiProperty` 데코레이터로 설정해 주어야 합니다.
- [ ] controller만 깔끔해 질 수 있습니다. (entity, dto는 이전처럼 api 관련 데코레이터 지정해줘야 함.
- [ ] controller에서도 controller 클래스의 제일 위쪽에 `@ApiTags('사용자 API')`처럼 ApiTag는 이전처럼 추가해 줘야 합니다.

# 참고
https://docs.nestjs.com/openapi/cli-plugin