### PR TITLE
Fix: 🐛 이미지가 null인 경우를 제외한 데이터만 가져옴

### DIFF
--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -136,7 +136,9 @@ export class FoodService {
     if (!hotLevel) {
       // hotLevel 없고, category도 없는 경우
       if (!category) {
-        const query = this.foodRepository.createQueryBuilder('food');
+        const query = this.foodRepository
+          .createQueryBuilder('food')
+          .where('food.imageUrl is not null');
 
         return sortBy(query, sort)
           .take(size)
@@ -148,7 +150,8 @@ export class FoodService {
       const query = this.foodRepository
         .createQueryBuilder('food')
         .leftJoinAndSelect('food.categories', 'category')
-        .where('category.name = :categoryName', { categoryName: category });
+        .where('category.name = :categoryName', { categoryName: category })
+        .andWhere('food.imageUrl is not null');
 
       return sortBy(query, sort).take(size).getMany().then(produceFindFoodDto);
     }
@@ -161,7 +164,8 @@ export class FoodService {
       const query = this.foodRepository
         .createQueryBuilder('food')
         .leftJoinAndSelect('food.foodLevel', 'foodLevel')
-        .where('foodLevel.id = :hotLevelId', { hotLevelId });
+        .where('foodLevel.id = :hotLevelId', { hotLevelId })
+        .andWhere('food.imageUrl is not null');
 
       return sortBy(query, sort).take(size).getMany().then(produceFindFoodDto);
     }
@@ -170,7 +174,8 @@ export class FoodService {
       .leftJoinAndSelect('food.categories', 'category')
       .leftJoinAndSelect('food.foodLevel', 'foodLevel')
       .where('category.name = :categoryName', { categoryName: category })
-      .andWhere('foodLevel.id = :hotLevelId', { hotLevelId });
+      .andWhere('foodLevel.id = :hotLevelId', { hotLevelId })
+      .andWhere('food.imageUrl is not null');
 
     return sortBy(query, sort).take(size).getMany().then(produceFindFoodDto);
   }


### PR DESCRIPTION
✅ Closes: #91

# 주제

- 음식 리스트 API에서 imageUrl 값이 null 인경우 반환이 안되도록 처리합니다.

# 작업 완료 내용 (자세히 작성)

- `GET` `/food` API 수정

# 관련 이슈 번호

- #91

# 미작업 내용

- x

# 주의사항

- [ ] x
